### PR TITLE
Fix: AbstractContent::getParserOutput was deprecated in MW 1.38

### DIFF
--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -164,16 +164,12 @@ class ContentParser {
 				$this->parserOutput = $contentRenderer->getParserOutput(
 					$content,
 					$this->getTitle(),
-					$revision->getId(),
-					null,
-					true
+					$revision->getId()
 				);
 			} else {
 				$this->parserOutput = $content->getParserOutput(
 					$this->getTitle(),
-					$revision->getId(),
-					null,
-					true
+					$revision->getId()
 				);
 			}
 		} catch( \MWUnknownContentModelException $e ) {

--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -2,13 +2,13 @@
 
 namespace SMW;
 
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRecord;
 use Parser;
 use ParserOptions;
 use Title;
 use User;
-use SMW\MediaWiki\RevisionGuard;
 use SMW\MediaWiki\RevisionGuardAwareTrait;
 
 /**
@@ -150,17 +150,32 @@ class ContentParser {
 		$content = $revision->getContent( SlotRecord::MAIN, RevisionRecord::RAW );
 
 		if ( !$content ) {
-			$content = $revision->getContentHandler()->makeEmptyContent();
+			$mainSlot = $revision->getSlot( SlotRecord::MAIN, RevisionRecord::RAW );
+			$contentHandlerFactory = MediaWikiServices::getInstance()->getContentHandlerFactory();
+			$handler = $contentHandlerFactory->getContentHandler( $mainSlot->getModel() );
+			$content = $handler->makeEmptyContent();
 		}
 
 		// Avoid "The content model 'xyz' is not registered on this wiki."
 		try {
-			$this->parserOutput = $content->getParserOutput(
-				$this->getTitle(),
-				$revision->getId(),
-				null,
-				true
-			);
+			$services = MediaWikiServices::getInstance();
+			if ( method_exists( $services, 'getContentRenderer' ) ) {
+				$contentRenderer = $services->getContentRenderer();
+				$this->parserOutput = $contentRenderer->getParserOutput(
+					$content,
+					$this->getTitle(),
+					$revision->getId(),
+					null,
+					true
+				);
+			} else {
+				$this->parserOutput = $content->getParserOutput(
+					$this->getTitle(),
+					$revision->getId(),
+					null,
+					true
+				);
+			}
 		} catch( \MWUnknownContentModelException $e ) {
 			$this->parserOutput = null;
 		}


### PR DESCRIPTION
Also fix invalid usage of `$revision->getContentHandler()`